### PR TITLE
Move screenshot image below instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ Launch a ready-to-code Wagtail development environment with a single click.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wagtail/wagtail-gitpod)
 
-![Wagtail Gitpod screenshot](https://user-images.githubusercontent.com/1969342/82453552-f4c9aa00-9ab0-11ea-90ce-e37b5f680f8d.png)
-
 Steps:
 
 1. Click the ``Open in Gitpod`` button.
-2. Relax: A development environment with an active Wagtail site will be created for you.
+2. Relax: a development environment with an active Wagtail site will be created for you.
 3. Login at `/admin/` with username `admin` and password `changeme`
 
-You have now skipped the first part of the Wagtail tutorial. 
+You have skipped the first part of the Wagtail tutorial. 
 Continue the tutorial at [Extend the HomePage model](https://docs.wagtail.io/en/stable/getting_started/tutorial.html#extend-the-homepage-model).
 
- 
+![Wagtail Gitpod screenshot](https://user-images.githubusercontent.com/1969342/82453552-f4c9aa00-9ab0-11ea-90ce-e37b5f680f8d.png)


### PR DESCRIPTION
The README is opened in preview mode when the Gitpod workspace starts, and the screenshot image hides the next steps at normal screen sizes.