### PR TITLE
Delete Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn locallibrary.wsgi --log-file -


### PR DESCRIPTION
I'm pretty sure this isn't needed - I think it was copied from Gitpod's example repo, which was originally based on a Heroku-enabled example (https://github.com/gitpod-io/django-locallibrary-tutorial).