### PR TITLE
Add hit counter

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@ ports:
   onOpen: open-preview
 tasks:
 - init: >
+    python -c "from urllib.request import urlopen; urlopen('https://hitcounter.pythonanywhere.com/count/tag.svg?url=https%3A%2F%2Fgithub.com%2Fwagtail%2Fwagtail-gitpod')" &&
     python -m pip install wagtail &&
     wagtail start mysite . &&
     python -m pip install -r requirements.txt &&

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ You have skipped the first part of the Wagtail tutorial.
 Continue the tutorial at [Extend the HomePage model](https://docs.wagtail.io/en/stable/getting_started/tutorial.html#extend-the-homepage-model).
 
 ![Wagtail Gitpod screenshot](https://user-images.githubusercontent.com/1969342/82453552-f4c9aa00-9ab0-11ea-90ce-e37b5f680f8d.png)
+
+![Wagtail Gitpod hit counter](https://hitcounter.pythonanywhere.com/nocount/tag.svg?url=https%3A%2F%2Fgithub.com%2Fwagtail%2Fwagtail-gitpod)


### PR DESCRIPTION
Note that the .gitpod.yaml uses the `count` url and de readme.md the `nocount`. 
So this counter only counts gitpod instances started.