### PR TITLE
Add custom docker to preseve pip modules

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+ENV PIP_USER=yes

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
   - init: |
       python -m pip install wagtail


### PR DESCRIPTION
Current gitpod console output:
```
...
  Applying wagtailusers.0008_userprofile_avatar... OK
  Applying wagtailusers.0009_userprofile_verbose_name_plural... OK
  Applying wagtailusers.0010_userprofile_updated_comments_notifications... OK
exit

🤙 This task ran as a workspace prebuild

Traceback (most recent call last):
  File "manage.py", line 8, in <module>
    from django.core.management import execute_from_command_line
ModuleNotFoundError: No module named 'django'
gitpod /workspace/wagtail-gitpod (main) $ 
```

The Python packages are lost after init :/ This PR makes them persist.
Ref: https://github.com/gitpod-io/gitpod/issues/7078#issuecomment-997139674